### PR TITLE
build: enable vibevoice TTS by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ cmake_minimum_required(VERSION 3.15)
 option(ARBITERAI_ENABLE_LLAMA "Enable local llama.cpp model runtime support" ON)
 option(ARBITERAI_ENABLE_WHISPER "Enable local whisper.cpp speech-to-text support" OFF)
 option(ARBITERAI_ENABLE_STABLE_DIFFUSION "Enable local stable-diffusion.cpp image generation support" OFF)
-option(ARBITERAI_ENABLE_VIBEVOICE "Enable local vibevoice.cpp text-to-speech support" OFF)
+option(ARBITERAI_ENABLE_VIBEVOICE "Enable local vibevoice.cpp text-to-speech support" ON)
 option(ARBITERAI_ENABLE_ORPHEUS "Enable local Orpheus TTS via a dlopen'd chatllm.cpp engine library" OFF)
 option(ARBITERAI_ENABLE_SHERPA "Enable local audio (STT / speaker embedding / audio tagging) via sherpa-onnx" ON)
 


### PR DESCRIPTION
Applies the same policy as sherpa-onnx (#25): an engine ships ON once it is verified functional. vibevoice is the TTS provider actually in use — it is what the /v1/audio/speech endpoint serves in our deployment, and orpheus, the only other TTS engine, is broken (returns ~0.17s of truncated audio).

Build side verified: the vcpkg port installs and links (libvibevoice.a + vibevoice_capi.h), and thanks to the option -> manifest-feature wiring added in #25 this is now a one-line change rather than needing VCPKG_MANIFEST_FEATURES passed by hand.

Runtime caveat: vibevoice-0.5b currently returns model_load_error on our test host. That looks like model-weight staging rather than engine breakage — sensevoice fails identically there while other sherpa-onnx models on the same server (speaker-embedding, audio-tagging) answer normally, so the engines load fine and the affected weights are simply not staged. Synthesis was previously confirmed working on this engine (~1.9s, well-formed audio). Worth re-confirming against a host with the weights staged before this merges.


Claude-Session: https://claude.ai/code/session_016AmZUBLnceGdLFHcmtmWCt